### PR TITLE
ci: correctly encode assignees

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -71,8 +71,8 @@ jobs:
             - [ ] `make signer` to sign files
             - [ ] `make collector` to gather information about current chain versions
             - [ ] `make cleaner` to remove obsolete QRs
-          assignees:
-            - FlorianFranzen
+          assignees: |
+            FlorianFranzen
           draft: true
 
       - name: Notify Matrix channel


### PR DESCRIPTION
Always forget custom composite actions only take strings.